### PR TITLE
add support for monitoring

### DIFF
--- a/views/raw.py
+++ b/views/raw.py
@@ -8,6 +8,7 @@ from . import crypto
 
 class Raw(object):
     file_entries, fs = loadconfig.get_cache_db()
+    r = file_entries.create_index("timestamp")
 
     def on_post(self, req, resp):
         try:
@@ -20,14 +21,14 @@ class Raw(object):
                 if part.name == 'file':
                     fenc = crypto.encrypt_file(part.stream.read())
                     info['fid'] = self.fs.put(fenc, filename=part.filename)
-                elif part.name in ['typetag', 'name', 'orgid', 'timezone']:
+                elif part.name in ['typetag', 'name', 'orgid', 'timezone','config_hash']:
                     info[part.name] = part.text
                 else:
                     resp.media = {"message": "Invalid input: " + part.name}
                     resp.status = falcon.HTTP_400
                     return
 
-            required_keys = ['typetag', 'name', 'orgid', 'timezone', 'fid']
+            required_keys = ['typetag', 'name', 'orgid', 'timezone', 'fid']#,'config_hash']
             if not all(key in info for key in required_keys):
                 resp.media = {"message": "Incomplete input"}
                 resp.status = falcon.HTTP_400


### PR DESCRIPTION
this adds support for the config hash to be posted with the data, if the `config_hash` field is given then the monitoring script can reference it to be able to detect traffic from that source.

`config_hash` was not added to the required field because if its missing then inputs wont be able to post. but if its posted then it will be able to be monitored.